### PR TITLE
Change build target to es5 to support older browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ yarn add limited-promise
 
 Using npm...
 ```
-$ npm install limited-promise
+$ npm install limited-promise --save
 ```
 
 ## Usage
@@ -38,6 +38,23 @@ In the above scenario, the first 10 tasks will fire immediately. The next
 
 If new tasks arrive before the scheduled token debt has been paid off (time passes),
 then new tokens will be scheduled for the future.
+
+### Initial Balance
+
+If you want to set a higher initial balance of tokens (to allow for a burst of tasks on
+app startup for example), you can pass a custom initial limit.
+
+```typescript
+const config: LimitedPromiseConfig = {
+  tokens: 10,      // maximum burst "immediate" usages
+  tokenCredit: 10, // maximum tasks that can be scheduled
+  rate: 10         // refill rate (requests per second)
+}
+
+const initialBalance: number = 100;
+
+const bucket = new LimitedPromise(config, initialBalance);
+```
 
 ## Notes on Implementation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limited-promise",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Rate Limited Promises powered by a credit-allowing Lazy Token Bucket",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "sourceMap": true,
-    "target": "es6",
+    "target": "es5",
     "lib": ["es2017", "es7", "es6", "dom"],
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
This will allow projects to use limited-promise on older browsers without having to transpile their node modules, which gets very slow