### PR TITLE
Prevent Huge Negative Balances if you move your device time back

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limited-promise",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Rate Limited Promises powered by a credit-allowing Lazy Token Bucket",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,9 @@ export default class LimitedPromise {
     if (this._balance < this.config.tokens) {
       const addedTokens = dt / 1000.0 * this.config.rate
       this._balance = Math.min(this._balance + addedTokens, this.config.tokens)
+
+      //this prevents large negative balances if your device time changes
+      this._balance = Math.max(this._balance, -this.config.tokenCredit)
     }
 
     // Time to calculate duration


### PR DESCRIPTION
I noticed some users with huge (like up to -100,000) negative token balances. Looking through the logic, the only thing I can see that would cause a balance below your credit would be if the device time changed. 

I was able to verify that it does happen, and that this changed fixes it (you will still have a negative balance, but it will just be `-tokenCredit`.

I looked around and this is difficult to write a unit test for because jest does not allow for mocking the Date constructor.